### PR TITLE
Render Restricted Area for Roots

### DIFF
--- a/Assets/Prefabs/Plant/OakTree.prefab
+++ b/Assets/Prefabs/Plant/OakTree.prefab
@@ -50,6 +50,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61b05e8511b8c6043b8e7c246d38ab35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  rootsMask: {fileID: 21300000, guid: 5acf4ea37e744b84a8921bb3d4893791, type: 3}
   plantType: 1
   cost:
     Water: 100
@@ -103,7 +104,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -836974183
-  m_SortingLayer: 2
+  m_SortingLayer: 3
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 45ccc187f7a84994985df9b7013f7f8c, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Plant/Roots.meta
+++ b/Assets/Prefabs/Plant/Roots.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c66f7c62656c634419fab405d97f393d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Plant/Roots/RestrictedArea.prefab
+++ b/Assets/Prefabs/Plant/Roots/RestrictedArea.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &9133241677157320523
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9133241677157320521}
+  - component: {fileID: 9133241677157320520}
+  m_Layer: 0
+  m_Name: RestrictedArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9133241677157320521
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9133241677157320523}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!331 &9133241677157320520
+SpriteMask:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9133241677157320523}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 256
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 5acf4ea37e744b84a8921bb3d4893791, type: 3}
+  m_MaskAlphaCutoff: 0.2
+  m_FrontSortingLayerID: 0
+  m_BackSortingLayerID: 0
+  m_FrontSortingLayer: 0
+  m_BackSortingLayer: 0
+  m_FrontSortingOrder: 0
+  m_BackSortingOrder: 0
+  m_IsCustomRangeActive: 0
+  m_SpriteSortPoint: 0

--- a/Assets/Prefabs/Plant/Roots/RestrictedArea.prefab.meta
+++ b/Assets/Prefabs/Plant/Roots/RestrictedArea.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 176b42a3528dd5e46aa496ad97f900a0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Plant/Roots/RootsLayer.prefab
+++ b/Assets/Prefabs/Plant/Roots/RootsLayer.prefab
@@ -10,6 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 517641001331456310}
   - component: {fileID: 517641001331456311}
+  - component: {fileID: 1577069144}
   m_Layer: 0
   m_Name: RootsLayer
   m_TagString: Untagged
@@ -24,7 +25,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 517641001331456309}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -89,3 +90,16 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 1
   m_SpriteSortPoint: 0
+--- !u!114 &1577069144
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 517641001331456309}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 726ef04558ce8bc489f32202cc91c87e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rootType: 0

--- a/Assets/Prefabs/Plant/Roots/RootsLayer.prefab
+++ b/Assets/Prefabs/Plant/Roots/RootsLayer.prefab
@@ -1,0 +1,91 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &517641001331456309
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 517641001331456310}
+  - component: {fileID: 517641001331456311}
+  m_Layer: 0
+  m_Name: RootsLayer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &517641001331456310
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 517641001331456309}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!212 &517641001331456311
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 517641001331456309}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 256
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 463737433
+  m_SortingLayer: 2
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 2273a597df801d744bccc72827f7cfe7, type: 3}
+  m_Color: {r: 0.9528302, g: 0.5456442, b: 0.48989856, a: 0.39607844}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 2
+  m_Size: {x: 100, y: 100}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 1
+  m_SpriteSortPoint: 0

--- a/Assets/Prefabs/Plant/Roots/RootsLayer.prefab.meta
+++ b/Assets/Prefabs/Plant/Roots/RootsLayer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 08513b75238f2f24fb22439a172e949f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Plant/Sunflower.prefab
+++ b/Assets/Prefabs/Plant/Sunflower.prefab
@@ -50,6 +50,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61b05e8511b8c6043b8e7c246d38ab35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  rootsMask: {fileID: 21300000, guid: 5acf4ea37e744b84a8921bb3d4893791, type: 3}
   plantType: 0
   cost:
     Water: 10
@@ -103,7 +104,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -836974183
-  m_SortingLayer: 2
+  m_SortingLayer: 3
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: 0bef886f3e6827543b64a0b28d10e613, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Prefabs/Plant/Watermelon.prefab
+++ b/Assets/Prefabs/Plant/Watermelon.prefab
@@ -50,6 +50,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 61b05e8511b8c6043b8e7c246d38ab35, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  rootsMask: {fileID: 21300000, guid: 5acf4ea37e744b84a8921bb3d4893791, type: 3}
   plantType: 0
   cost:
     Water: 0
@@ -104,7 +105,7 @@ SpriteRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: -836974183
-  m_SortingLayer: 2
+  m_SortingLayer: 3
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: f7210d9826fc6d4459a477496696443f, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -626,7 +626,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 517641001331456309, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
       propertyPath: m_Name
-      value: RootsLayer
+      value: RestrictedRootsLayer
       objectReference: {fileID: 0}
     - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
       propertyPath: m_Pivot.x

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -617,3 +617,100 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &517641002774287201
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 517641001331456309, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_Name
+      value: RootsLayer
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_RootOrder
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 517641001331456310, guid: 08513b75238f2f24fb22439a172e949f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 08513b75238f2f24fb22439a172e949f, type: 3}

--- a/Assets/Scripts/Plants/Plant.cs
+++ b/Assets/Scripts/Plants/Plant.cs
@@ -154,7 +154,7 @@ namespace nickmaltbie.IntoTheRoots.Plants
             float diameter = restrictedDistance * 2;
             restrictedArea.sprite = rootsMask;
             restrictedArea.transform.localScale = new Vector3(diameter, diameter, 1);
-            restrictedArea.renderingLayerMask = RenderLayerMasks.RootsRenderLayer;
+            restrictedArea.renderingLayerMask = RenderLayerMasks.RestrictedRootsRenderLayer;
         }
 
         public void Update()

--- a/Assets/Scripts/Plants/Plant.cs
+++ b/Assets/Scripts/Plants/Plant.cs
@@ -186,7 +186,7 @@ namespace nickmaltbie.IntoTheRoots.Plants
             {
                 resources.AddResources(produced.Item1, produced.Item2);
                 //Produce corresponding resource particle effect
-                var ts = resourceParticle.textureSheetAnimation;
+                ParticleSystem.TextureSheetAnimationModule ts = resourceParticle.textureSheetAnimation;
                 ts.SetSprite(0, resourceSprites.GetIcon(produced.Item1));
                 resourceParticle.Play();
             }

--- a/Assets/Scripts/Plants/Plant.cs
+++ b/Assets/Scripts/Plants/Plant.cs
@@ -17,6 +17,7 @@
 // SOFTWARE.
 
 using nickmaltbie.IntoTheRoots.Player;
+using nickmaltbie.IntoTheRoots.UI;
 using Unity.Netcode;
 using UnityEngine;
 
@@ -24,6 +25,7 @@ namespace nickmaltbie.IntoTheRoots.Plants
 {
     public enum PlantType
     {
+        None,
         Producer,
         Tree,
         Vegetable,
@@ -33,6 +35,12 @@ namespace nickmaltbie.IntoTheRoots.Plants
     [RequireComponent(typeof(Collider2D))]
     public class Plant : NetworkBehaviour
     {
+        /// <summary>
+        /// Circle mask for roots layer.
+        /// </summary>
+        [SerializeField]
+        public Sprite rootsMask;
+
         /// <summary>
         /// Name of this type of plant.
         /// </summary>
@@ -91,6 +99,11 @@ namespace nickmaltbie.IntoTheRoots.Plants
         private ParticleSystem resourceParticle;
 
         /// <summary>
+        /// Restricted area for drawing roots.
+        /// </summary>
+        private SpriteMask restrictedArea;
+
+        /// <summary>
         /// Get the radius of this object
         /// </summary>
         /// <returns></returns>
@@ -113,12 +126,35 @@ namespace nickmaltbie.IntoTheRoots.Plants
             }
         }
 
+        public void SetRestrictedAreaVisible(bool visible)
+        {
+            restrictedArea.enabled = visible;
+        }
+
         public void Start()
         {
             SpriteRenderer sr = GetComponent<SpriteRenderer>();
             Collider2D collider = GetComponent<Collider2D>();
             sr.sortingOrder = -Mathf.RoundToInt(collider.bounds.min.y * 100);
             resourceParticle = GetComponent<ParticleSystem>();
+
+            if (IsOwner)
+            {
+                VisualizeRange();
+                SetRestrictedAreaVisible(PlantIconTableau.Singleton.SelectedType() == plantType);
+            }
+        }
+
+        public void VisualizeRange()
+        {
+            restrictedArea = new GameObject().AddComponent<SpriteMask>();
+            restrictedArea.transform.SetParent(transform);
+            restrictedArea.transform.localPosition = Vector3.zero;
+
+            float diameter = restrictedDistance * 2;
+            restrictedArea.sprite = rootsMask;
+            restrictedArea.transform.localScale = new Vector3(diameter, diameter, 1);
+            restrictedArea.renderingLayerMask = RenderLayerMasks.RootsRenderLayer;
         }
 
         public void Update()

--- a/Assets/Scripts/Plants/PlantUtils.cs
+++ b/Assets/Scripts/Plants/PlantUtils.cs
@@ -36,6 +36,12 @@ namespace nickmaltbie.IntoTheRoots.Plants
             return Physics2D.GetLayerCollisionMask(mask);
         }
 
+        public static IEnumerable<Plant> GetAllPlayerPlantsOfType(ulong owner, PlantType plantType)
+        {
+            return GameObject.FindObjectsOfType<Plant>()
+                .Where(plant => plant.OwnerClientId == owner && plant.plantType == plantType);
+        }
+
         public static IEnumerable<Plant> GetPlantsInRadius(Vector2 position, float radius, ulong owner, PlantType type)
         {
             return GetPlantsInRadius(position, radius).Where(plant => plant.OwnerClientId == owner && plant.plantType == type);

--- a/Assets/Scripts/Plants/RootsArea.cs
+++ b/Assets/Scripts/Plants/RootsArea.cs
@@ -1,5 +1,21 @@
+// Copyright (C) 2023 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
-using nickmaltbie.IntoTheRoots;
 using UnityEngine;
 
 namespace nickmaltbie.IntoTheRoots.Plants

--- a/Assets/Scripts/Plants/RootsArea.cs
+++ b/Assets/Scripts/Plants/RootsArea.cs
@@ -1,0 +1,32 @@
+
+using nickmaltbie.IntoTheRoots;
+using UnityEngine;
+
+namespace nickmaltbie.IntoTheRoots.Plants
+{
+    public enum RootType
+    {
+        Restricted,
+        Grow,
+        Linking
+    }
+
+    [RequireComponent(typeof(SpriteRenderer))]
+    public class RootsArea : MonoBehaviour
+    {
+        public RootType rootType;
+
+        public void Awake()
+        {
+            SpriteRenderer sr = GetComponent<SpriteRenderer>();
+
+            switch (rootType)
+            {
+                case RootType.Restricted:
+                    sr.renderingLayerMask = RenderLayerMasks.RestrictedRootsRenderLayer;
+                    sr.maskInteraction = SpriteMaskInteraction.VisibleInsideMask;
+                    break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Plants/RootsArea.cs.meta
+++ b/Assets/Scripts/Plants/RootsArea.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 726ef04558ce8bc489f32202cc91c87e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/RenderLayerMasks.cs
+++ b/Assets/Scripts/RenderLayerMasks.cs
@@ -1,0 +1,9 @@
+
+
+namespace nickmaltbie.IntoTheRoots.UI
+{
+    public static class RenderLayerMasks
+    {
+        public const uint RootsRenderLayer = 1 << 8;
+    }
+}

--- a/Assets/Scripts/RenderLayerMasks.cs
+++ b/Assets/Scripts/RenderLayerMasks.cs
@@ -1,9 +1,9 @@
 
 
-namespace nickmaltbie.IntoTheRoots.UI
+namespace nickmaltbie.IntoTheRoots
 {
     public static class RenderLayerMasks
     {
-        public const uint RootsRenderLayer = 1 << 8;
+        public const uint RestrictedRootsRenderLayer = 1 << 8;
     }
 }

--- a/Assets/Scripts/RenderLayerMasks.cs
+++ b/Assets/Scripts/RenderLayerMasks.cs
@@ -1,4 +1,20 @@
-
+// Copyright (C) 2023 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 namespace nickmaltbie.IntoTheRoots
 {

--- a/Assets/Scripts/RenderLayerMasks.cs.meta
+++ b/Assets/Scripts/RenderLayerMasks.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3ab05ed368b1d848aade608102df21b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Terrain/Circle-Mask.png
+++ b/Assets/Sprites/Terrain/Circle-Mask.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3a7ff1d5f370deec6dd9249b0db5c419de662c5b609cac66bcb5ad5033f0df4
+size 4416

--- a/Assets/Sprites/Terrain/Circle-Mask.png.meta
+++ b/Assets/Sprites/Terrain/Circle-Mask.png.meta
@@ -1,0 +1,147 @@
+fileFormatVersion: 2
+guid: 5acf4ea37e744b84a8921bb3d4893791
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 512
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Terrain/roots.png
+++ b/Assets/Sprites/Terrain/roots.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ada45331dfb0b73a95e92948f9f99f0b3b28a716ca05a14c4ad4683da4f25500
+size 12338

--- a/Assets/Sprites/Terrain/roots.png.meta
+++ b/Assets/Sprites/Terrain/roots.png.meta
@@ -1,0 +1,147 @@
+fileFormatVersion: 2
+guid: 2273a597df801d744bccc72827f7cfe7
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 0
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 64
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -44,6 +44,9 @@ TagManager:
   - name: GrowRange
     uniqueID: 2730352973
     locked: 0
+  - name: RestrictedRange
+    uniqueID: 463737433
+    locked: 0
   - name: Plant
     uniqueID: 3457993113
     locked: 0


### PR DESCRIPTION
# Description

Rendering restricted area for roots.

Will only render for plants that are the same type as the type you are trying to plant for the Tableau.

![image](https://user-images.githubusercontent.com/3240136/216790111-f4ecf2f7-406d-4431-92af-5b2be691f403.png)

# How Has This Been Tested?

Tested change locally and with multiple clients via parallel sync.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
