### PR TITLE
Plant Icons Clickable

### DIFF
--- a/Assets/Prefabs/UI/Components/Plant/PlantIcon.prefab
+++ b/Assets/Prefabs/UI/Components/Plant/PlantIcon.prefab
@@ -90,6 +90,7 @@ GameObject:
   - component: {fileID: 722772023289241786}
   - component: {fileID: 722772023289241780}
   - component: {fileID: 7796133975923528653}
+  - component: {fileID: 6354850717139523492}
   m_Layer: 0
   m_Name: PlantIcon
   m_TagString: Untagged
@@ -148,6 +149,50 @@ MonoBehaviour:
   plantNumber: {fileID: 2937799195431333867}
   plantIndex: 0
   plant: {fileID: 0}
+--- !u!114 &6354850717139523492
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 722772023289241787}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 64701220313192021}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &726434427376618203
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/UI/PlantDetailsDisplay.cs
+++ b/Assets/Scripts/UI/PlantDetailsDisplay.cs
@@ -1,5 +1,21 @@
-using System.Collections;
-using System.Collections.Generic;
+// Copyright (C) 2023 Nicholas Maltbie
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+// associated documentation files (the "Software"), to deal in the Software without restriction,
+// including without limitation the rights to use, copy, modify, merge, publish, distribute,
+// sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all copies or
+// substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+// BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 using TMPro;
 using Unity.Netcode;
 using UnityEngine;
@@ -38,11 +54,6 @@ namespace nickmaltbie.IntoTheRoots
         /// TMP for water cost and water gain.
         /// </summary>
         public TextMeshProUGUI waterCost, waterGain;
-
-        private void Awake()
-        {
-            singleton = this;
-        }
 
         public static void UpdateDisplay(Plants.Plant selectedPlant)
         {

--- a/Assets/Scripts/UI/PlantIconTableau.cs
+++ b/Assets/Scripts/UI/PlantIconTableau.cs
@@ -22,6 +22,7 @@ using nickmaltbie.IntoTheRoots.Player;
 using Unity.Netcode;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using UnityEngine.UI;
 
 namespace nickmaltbie.IntoTheRoots.UI
 {
@@ -74,6 +75,13 @@ namespace nickmaltbie.IntoTheRoots.UI
                 icons[index].plant = plant;
                 icons[index].plantIndex = index;
                 icons[index].SetSelected(false);
+
+                if (icons[index].GetComponent<Button>() is Button button)
+                {
+                    int idx = index;
+                    button.onClick.AddListener(() => SetSelected(idx));
+                }
+
                 index++;
             }
 


### PR DESCRIPTION
# Description

Made plant icons clickable to select which player the player is attempting to place.

# How Has This Been Tested?

Tested locally to ensure player can click what they want to place.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that demonstrate the new feature or bugfix
- [x] New and existing unit and integrations tests pass locally with my changes
