### PR TITLE
Fix scroll direction, and add controller support

### DIFF
--- a/Assets/Input/InputSystem.inputactions
+++ b/Assets/Input/InputSystem.inputactions
@@ -567,6 +567,17 @@
                     "isPartOfComposite": false
                 },
                 {
+                    "name": "",
+                    "id": "ea3c008f-04fc-4b68-a1f1-950cc7ddf8b9",
+                    "path": "<Gamepad>/buttonSouth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Plant",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
                     "name": "Mouse Wheel",
                     "id": "32e1f8f3-57bd-4356-9140-372c0aeb74fb",
                     "path": "1DAxis",
@@ -578,7 +589,7 @@
                     "isPartOfComposite": false
                 },
                 {
-                    "name": "positive",
+                    "name": "negative",
                     "id": "3f90d6e8-26bd-46b3-b6a0-e6c9a37981ae",
                     "path": "<Mouse>/scroll/up",
                     "interactions": "",
@@ -589,9 +600,42 @@
                     "isPartOfComposite": true
                 },
                 {
-                    "name": "negative",
+                    "name": "positive",
                     "id": "48b8680c-19fe-43f7-ad1f-660ee8a73615",
                     "path": "<Mouse>/scroll/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ChangePlant",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Bumpers",
+                    "id": "c80a46d8-5ef5-456c-9a6e-03a6f10afdb3",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ChangePlant",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "negative",
+                    "id": "f04bbb83-9887-477d-a3da-b3206f411925",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "ChangePlant",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "c6be1821-4f77-4e8f-b402-4a21984b7946",
+                    "path": "<Gamepad>/rightShoulder",
                     "interactions": "",
                     "processors": "",
                     "groups": "",


### PR DESCRIPTION
# Description

Change input so scrolling down moves plant selection to the right, a la Minecraft.

Also add first pass at button support for controllers - XBox A to plant, bumpers to select.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that demonstrate the new feature or bugfix
- [ ] New and existing unit and integrations tests pass locally with my changes
