### PR TITLE
Highlight needed resources in display

### DIFF
--- a/Assets/Prefabs/UI/Components/Plant/PlantDetailsDisplay.prefab
+++ b/Assets/Prefabs/UI/Components/Plant/PlantDetailsDisplay.prefab
@@ -239,6 +239,9 @@ MonoBehaviour:
   sunGain: {fileID: 887667829116890802}
   waterCost: {fileID: 4352330826868376630}
   waterGain: {fileID: 3837541932733836638}
+  seedSprite: {fileID: 3136128545931094923}
+  sunSprite: {fileID: 8738227858125197870}
+  waterSprite: {fileID: 1041568708902079978}
 --- !u!1 &1441388897442341493
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Player/Planter.cs
+++ b/Assets/Scripts/Player/Planter.cs
@@ -49,23 +49,27 @@ namespace nickmaltbie.IntoTheRoots.Player
             ResourceValues cost = plant.cost;
             PlayerResources stored = GetComponent<PlayerResources>();
 
+            bool verdict = true;
+
             foreach (Resource resource in Enum.GetValues(typeof(Resource)))
             {
                 int required = cost.GetResourceValue(resource);
                 int current = stored.GetResourceCount(resource);
 
-                if (required <= 0)
-                {
-                    continue;
-                }
-
                 if (required > current)
                 {
-                    return false;
+                    // cannot plant
+                    PlantDetailsDisplay.Singleton.SetResourceHighlight(resource, true);
+                    verdict = false;
+                }
+                else
+                {
+                    // can plant
+                    PlantDetailsDisplay.Singleton.SetResourceHighlight(resource, false);
                 }
             }
 
-            return true;
+            return verdict;
         }
 
         public bool CanPlant(Plant target)

--- a/Assets/Scripts/Player/Planter.cs
+++ b/Assets/Scripts/Player/Planter.cs
@@ -49,7 +49,34 @@ namespace nickmaltbie.IntoTheRoots.Player
             ResourceValues cost = plant.cost;
             PlayerResources stored = GetComponent<PlayerResources>();
 
-            bool verdict = true;
+            foreach (Resource resource in Enum.GetValues(typeof(Resource)))
+            {
+                int required = cost.GetResourceValue(resource);
+                int current = stored.GetResourceCount(resource);
+
+                if (required <= 0)
+                {
+                    continue;
+                }
+
+                if (required > current)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public void Update()
+        {
+            UpdatePlantDisplay();
+        }
+
+        public void UpdatePlantDisplay()
+        {
+            ResourceValues cost = toPlant.cost;
+            PlayerResources stored = GetComponent<PlayerResources>();
 
             foreach (Resource resource in Enum.GetValues(typeof(Resource)))
             {
@@ -60,7 +87,6 @@ namespace nickmaltbie.IntoTheRoots.Player
                 {
                     // cannot plant
                     PlantDetailsDisplay.Singleton.SetResourceHighlight(resource, true);
-                    verdict = false;
                 }
                 else
                 {
@@ -68,8 +94,6 @@ namespace nickmaltbie.IntoTheRoots.Player
                     PlantDetailsDisplay.Singleton.SetResourceHighlight(resource, false);
                 }
             }
-
-            return verdict;
         }
 
         public bool CanPlant(Plant target)

--- a/Assets/Scripts/UI/PlantDetailsDisplay.cs
+++ b/Assets/Scripts/UI/PlantDetailsDisplay.cs
@@ -88,7 +88,7 @@ namespace nickmaltbie.IntoTheRoots
 
         private void SetResoureAsNeeded(Image resourceImage, bool isNeeded)
         {
-            if(isNeeded)
+            if (isNeeded)
             {
                 resourceImage.color = this.orange;
             }
@@ -98,9 +98,9 @@ namespace nickmaltbie.IntoTheRoots
             }
         }
 
-        public void SetResourceHighlight( Plants.Resource resource, bool isNeeded )
+        public void SetResourceHighlight(Plants.Resource resource, bool isNeeded)
         {
-            switch( resource )
+            switch (resource)
             {
                 case Plants.Resource.Seeds:
                     SetResoureAsNeeded(seedSprite, isNeeded);

--- a/Assets/Scripts/UI/PlantDetailsDisplay.cs
+++ b/Assets/Scripts/UI/PlantDetailsDisplay.cs
@@ -19,6 +19,7 @@
 using TMPro;
 using Unity.Netcode;
 using UnityEngine;
+using UnityEngine.UI;
 
 namespace nickmaltbie.IntoTheRoots
 {
@@ -55,6 +56,11 @@ namespace nickmaltbie.IntoTheRoots
         /// </summary>
         public TextMeshProUGUI waterCost, waterGain;
 
+        /// <summary>
+        /// Images for resource types.
+        /// </summary>
+        public Image seedSprite, sunSprite, waterSprite;
+
         public void Awake()
         {
             Singleton = this;
@@ -74,6 +80,36 @@ namespace nickmaltbie.IntoTheRoots
 
                 Singleton.description.text = selectedPlant.plantDescription;
                 Singleton.plantName.text = selectedPlant.GetComponent<NetworkBehaviour>().name;
+            }
+        }
+
+        private void SetResoureAsNeeded(Image resourceImage, bool isNeeded)
+        {
+            if(isNeeded)
+            {
+                resourceImage.color = Color.yellow;
+            }
+            else
+            {
+                resourceImage.color = Color.white;
+            }
+        }
+
+        public void SetResourceHighlight( Plants.Resource resource, bool isNeeded )
+        {
+            switch( resource )
+            {
+                case Plants.Resource.Seeds:
+                    SetResoureAsNeeded(seedSprite, isNeeded);
+                    break;
+                case Plants.Resource.Sun:
+                    SetResoureAsNeeded(sunSprite, isNeeded);
+                    break;
+                case Plants.Resource.Water:
+                    SetResoureAsNeeded(seedSprite, isNeeded);
+                    break;
+                default:
+                    break;
             }
         }
     }

--- a/Assets/Scripts/UI/PlantDetailsDisplay.cs
+++ b/Assets/Scripts/UI/PlantDetailsDisplay.cs
@@ -61,9 +61,12 @@ namespace nickmaltbie.IntoTheRoots
         /// </summary>
         public Image seedSprite, sunSprite, waterSprite;
 
+        private Color orange;
+
         public void Awake()
         {
             Singleton = this;
+            orange = Color.Lerp(Color.red, Color.yellow, 0.5f);
         }
 
         public static void UpdateDisplay(Plants.Plant selectedPlant)
@@ -87,7 +90,7 @@ namespace nickmaltbie.IntoTheRoots
         {
             if(isNeeded)
             {
-                resourceImage.color = Color.yellow;
+                resourceImage.color = this.orange;
             }
             else
             {
@@ -106,7 +109,7 @@ namespace nickmaltbie.IntoTheRoots
                     SetResoureAsNeeded(sunSprite, isNeeded);
                     break;
                 case Plants.Resource.Water:
-                    SetResoureAsNeeded(seedSprite, isNeeded);
+                    SetResoureAsNeeded(waterSprite, isNeeded);
                     break;
                 default:
                     break;


### PR DESCRIPTION
# Description

Added code which highlights resources in the plant display if the player doesn't have enough to plant the selected plant.

All resources needed:
![image](https://user-images.githubusercontent.com/37094203/216825840-d38803ba-4757-4549-a067-5bd0a65528da.png)

Sun and Water are needed:
![image](https://user-images.githubusercontent.com/37094203/216825870-575a9c72-2ead-453b-aaef-d94ee0166356.png)


All resources good:
![All resources are sufficient](https://user-images.githubusercontent.com/37094203/216824806-3540c9a0-cf58-44b7-939f-7e536b4707a2.png)

